### PR TITLE
Updating return types to match Laravel 9 conventions

### DIFF
--- a/src/Entities/Attributes.php
+++ b/src/Entities/Attributes.php
@@ -240,7 +240,7 @@ class Attributes implements ArrayAccess, Arrayable
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return array_key_exists($key, $this->items);
     }
@@ -252,7 +252,7 @@ class Attributes implements ArrayAccess, Arrayable
      *
      * @return mixed
      */
-    public function offsetGet($key)
+    public function offsetGet($key): mixed
     {
         return $this->items[$key];
     }
@@ -265,7 +265,7 @@ class Attributes implements ArrayAccess, Arrayable
      *
      * @return void
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->items[$key] = $value;
     }
@@ -277,7 +277,7 @@ class Attributes implements ArrayAccess, Arrayable
      *
      * @return void
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->items[$key]);
     }

--- a/src/Entities/Attributes/ClassAttribute.php
+++ b/src/Entities/Attributes/ClassAttribute.php
@@ -192,7 +192,7 @@ class ClassAttribute extends AbstractAttribute implements Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->all());
     }


### PR DESCRIPTION
Ran into an issue with the return types not being specified in this package while using the ARCANEDEV/noCAPTCHA package.

Laravel Upgrade Docs:
https://laravel.com/docs/9.x/upgrade#php-return-types